### PR TITLE
Bootstrap導入時の問題を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,4 @@
-@import "bootstrap";
+@import "bootstrap/scss/bootstrap";
 
 .alert-notice {
     @extend .alert-success;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -6,17 +6,4 @@ require("@rails/ujs").start()
 require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
-require("jquery")
-import "bootstrap";
-import "../../assets/stylesheets/application";
-
-
-// Uncomment to copy all static images under ../images to the output folder and reference
-// them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
-// or the `imagePath` JavaScript helper below.
-//
-// const images = require.context('../images', true)
-// const imagePath = (name) => images(name, true)
-//= require jquery3
-//= require popper
-//= require bootstrap-sprockets
+require("bootstrap/dist/js/bootstrap")

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,8 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= stylesheet_pack_tag "application", media: "all", "data-turbolinks-track": "reload" %>
   </head>
 
   <body>


### PR DESCRIPTION
## 概要

- Bootstrap関連の不具合の修正

### 内容

- Rails 5の導入方法が混ざっている箇所を修正
- スタイル設定が効かなくなった原因である`app/views/layouts/application.html.erb`の変更を戻す