### PR TITLE
28_動画ページ群の追加

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,6 +1,8 @@
 class MoviesController < ApplicationController
 
   def index
-    @movies = Movie.page(params[:page])
+    default_categories = ['Basic', 'Git', 'Ruby', 'Ruby on Rails']
+    search_category = params[:category] || default_categories
+    @movies = Movie.where(category: search_category).page(params[:page])
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,7 +13,7 @@
           <div class="dropdown-menu" aria-labelledby="navbarDropdown">
             <%= link_to "動画教材", movies_path, class:"nav-item nav-link active text-primary" %>
             <a href="#" class="nav-item nav-link active text-primary">テキスト教材</a>
-            <a href="#" class="nav-item nav-link active text-primary">ライブコーディング</a>
+            <%= link_to "ライブコーディング", movies_path(category: "Live"), class:"nav-item nav-link active text-primary" %>
             <%= link_to "質問集", questions_path, class:"nav-item nav-link active text-primary" %>
             <!-- <a href="questions" class="nav-item nav-link active text-primary">質問集</a> -->
           </div>
@@ -23,19 +23,19 @@
           <!-- <a class="nav-link active" href="aws_texts">AWS講座</a> -->
         </li>
         <li class="nav-item">
-          <a class="nav-link active" href="#">PHP講座</a>
+          <%= link_to "PHP講座", movies_path(category: "Php"), class:"nav-link active" %>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" href="#">対談</a>
+          <%= link_to "対談", movies_path(category: "Talk"), class:"nav-link active" %>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" href="#">情報発信</a>
+          <%= link_to "情報発信", movies_path(category: "Marketing"), class:"nav-link active" %>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" href="#">動画編集講座</a>
+          <%= link_to "動画編集講座", movies_path(category: "Movie"), class:"nav-link active" %>
         </li>
         <li class="nav-item">
-          <a class="nav-link active" href="#">ライティング講座</a>
+          <%= link_to "ライティング講座", movies_path(category: "Writing"), class:"nav-link active" %>
         </li>
         <li class="nav-item">
           <a class="nav-link active" href="#">LINE@</a>

--- a/db/csv_data/movie_data.csv
+++ b/db/csv_data/movie_data.csv
@@ -1,32 +1,38 @@
-title,url
-人生逆転サロンの活用法,https://www.youtube.com/embed/iFMNUM2Q9mg
-Slackの使い方,https://www.youtube.com/embed/x_KeaEUr3jo
-プログラミングを学習するための基礎知識,https://www.youtube.com/embed/Outcx4StSyU
-Webとは,https://www.youtube.com/embed/DDBiKpcvZp0
-Webを支える技術,https://www.youtube.com/embed/wvkK06fdR3Q
-Webサーバーについて,https://www.youtube.com/embed/O6tARRY81xM
-動的ページと静的ページ,https://www.youtube.com/embed/R4GYLo9S7vQ
-Gitの基本,https://www.youtube.com/embed/cdz-cs_kYto
-Gitを使ったクローン、プルリク、マージの流れについて解説,https://www.youtube.com/embed/JispFS6zeDw
-ソースコードをリモートリポジトリにプッシュするときの流れ,https://www.youtube.com/embed/FIfbOSy1Bzg
-Rubyで使用する主なクラスについて,https://www.youtube.com/embed/BVv2JNnkKfU
-putsについて,https://www.youtube.com/embed/TFrYp4J6KLY
-変数について,https://www.youtube.com/embed/U3yqlU7HGnk
-ifについて,https://www.youtube.com/embed/SOLT-5evKQQ
-配列について,https://www.youtube.com/embed/o43AAYhNfU4
-繰り返し処理について,https://www.youtube.com/embed/6XGB0MkcQ2w
-ハッシュについて,https://www.youtube.com/embed/YJ1SOXyCx78
-Ruby/Railsの環境構築1,https://www.youtube.com/embed/owzClWksQJc
-Ruby/Railsの環境構築2,https://www.youtube.com/embed/92F2sWL3Xko
-Hello World アプリの解説（実践的なコントローラの作り方）,https://www.youtube.com/embed/1jMlnGwHiXo
-resourcesを使わないCRUDアプリの解説,https://www.youtube.com/embed/b_NlIEAQkoo
-resourcesを使ったCRUDアプリの解説,https://www.youtube.com/embed/QWixLhP62M8
-デバッグツールの使い方,https://www.youtube.com/embed/dmkzIosRytI
-CSVデータインポートアプリの解説,https://www.youtube.com/embed/KqOoZQoJTG8
-Rakeタスクの実装,https://www.youtube.com/embed/EntRvD_KSNA
-Deviseを使ったログイン機能の実装,https://www.youtube.com/embed/AIUsm87NyaM
-Active Admin を使った管理者画面の作成,https://www.youtube.com/embed/3auqochKXfg
-Ransackを使った検索機能の実装,https://www.youtube.com/embed/dATIhg6S0Us
-RSpecを使ったテストコードの実装,https://www.youtube.com/embed/Zo9HKyQqwfs
-RailsへのMarkdownの導入,https://www.youtube.com/embed/fFS5_GfXvwE
-Chart.jsを使ったグラフの作成,https://www.youtube.com/embed/05Cl4zekcGk
+category,title,url
+Basic,人生逆転サロンの活用法,https://www.youtube.com/embed/iFMNUM2Q9mg
+Basic,Slackの使い方,https://www.youtube.com/embed/x_KeaEUr3jo
+Basic,プログラミングを学習するための基礎知識,https://www.youtube.com/embed/Outcx4StSyU
+Git,Gitの基本,https://www.youtube.com/embed/cdz-cs_kYto
+Git,Gitを使ったクローン、プルリク、マージの流れについて解説,https://www.youtube.com/embed/JispFS6zeDw
+Git,ソースコードをリモートリポジトリにプッシュするときの流れ,https://www.youtube.com/embed/FIfbOSy1Bzg
+Ruby,Rubyで使用する主なクラスについて,https://www.youtube.com/embed/BVv2JNnkKfU
+Ruby,putsについて,https://www.youtube.com/embed/TFrYp4J6KLY
+Ruby,変数について,https://www.youtube.com/embed/U3yqlU7HGnk
+Ruby on Rails,Hello World アプリの解説（実践的なコントローラの作り方）,https://www.youtube.com/embed/1jMlnGwHiXo
+Ruby on Rails,resourcesを使わないCRUDアプリの解説,https://www.youtube.com/embed/b_NlIEAQkoo
+Ruby on Rails,resourcesを使ったCRUDアプリの解説,https://www.youtube.com/embed/QWixLhP62M8
+Ruby on Rails,デバッグツールの使い方,https://www.youtube.com/embed/dmkzIosRytI
+Ruby on Rails,CSVデータインポートアプリの解説,https://www.youtube.com/embed/KqOoZQoJTG8
+Ruby on Rails,Rakeタスクの実装,https://www.youtube.com/embed/EntRvD_KSNA
+Ruby on Rails,Deviseを使ったログイン機能の実装,https://www.youtube.com/embed/AIUsm87NyaM
+Talk,高卒・アラサーからプログラマーに転職したあじーさんのインタビュー,https://www.youtube.com/embed/jvSOJvq_kAg
+Talk,36歳携帯販売員からプログラマーに転職した田中さんのインタビュー,https://www.youtube.com/embed/f-MOZRFL1EQ
+Talk,機械学習エンジニアのとみーさん対談,https://www.youtube.com/embed/1H_Bwe1XHcE
+Live,【第1回】Twitterクローンアプリで学ぶアソシエーション勉強会,https://www.youtube.com/embed/mTeCYotISMk
+Live,【第2回】Twitterクローンアプリで学ぶアソシエーション勉強会,https://www.youtube.com/embed/V85-9-6wBtM
+Live,【初心者必見】Rails環境構築中のエラーを一緒に解決してみた,https://www.youtube.com/embed/qZEHjMtsEq0
+Movie,Lesson 0,https://www.youtube.com/embed/wbnxfybxlYU
+Movie,Lesson 1,https://www.youtube.com/embed/u3UTAz97eWg
+Movie,Lesson 2,https://www.youtube.com/embed/v9u0pZoGKww
+Movie,Lesson 3,https://www.youtube.com/embed/QVdaGrIFVdU
+Movie,Lesson 4,https://www.youtube.com/embed/3LZlqVwkOaw
+Movie,Lesson 5,https://www.youtube.com/embed/55TFAqkCCEI
+Php,Lesson 1,https://www.youtube.com/embed/qKy7X5umlqc
+Php,Lesson 2,https://www.youtube.com/embed/tvzdT5_mIv0
+Php,Lesson 3,https://www.youtube.com/embed/ZEh2SIKqkL0
+Php,Lesson 4,https://www.youtube.com/embed/u_oLIlZuLKE
+Writing,Lesson 1,https://www.youtube.com/embed/8WVV-gdtilE
+Writing,Lesson 2,https://www.youtube.com/embed/qhZlO-qa6kk
+Writing,Lesson 3,https://www.youtube.com/embed/H6kHT3iIvdQ
+Marketing,情報発信とは,https://www.youtube.com/embed/Wkorz--0xMo
+Marketing,集客を自動化しよう,https://www.youtube.com/embed/ClTzB1fmYyw

--- a/db/migrate/20200423014508_add_categoly_to_movies.rb
+++ b/db/migrate/20200423014508_add_categoly_to_movies.rb
@@ -1,0 +1,6 @@
+class AddCategolyToMovies < ActiveRecord::Migration[6.0]
+  def change
+    add_column :movies, :category, :string
+    add_index :movies, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_17_004958) do
+ActiveRecord::Schema.define(version: 2020_04_23_014508) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,8 @@ ActiveRecord::Schema.define(version: 2020_04_17_004958) do
     t.string "source_code_url"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "category"
+    t.index ["category"], name: "index_movies_on_category"
   end
 
   create_table "questions", force: :cascade do |t|


### PR DESCRIPTION
# 概要

逆転教材アプリで複数の動画ページ一覧を作成する
既存のMovieで作成したmodle,controller,viewを活用して、コードの共通を行う

### ブランチ名

`feature/movie_pages`

### 作成対象ページ

- ライブコーディング
- PHP
- 対談
- 情報発信
- 動画編集講座
- ライティング講座

## Routing

動画ページごとに新たなURLを追加するのではなく、既存のURL(movies)にたいして、パラメータとして、categoly(カテゴリ)を設定する。
(ex. ライブコーディングページの場合： ./movies?categoly=livecording )

`link_to`ヘルパーメソッドを以下のように設定

    <%= link_to "動画教材", movies_path(category: "livecording"), class:"nav-item nav-link active text-primary" %>

## Controller

URLに設定されたcategoryパラメーターを使用して、Movieモデルからデータを取得する。（categoryが設定されていない場合はデフォルトの値を使用）

## Model・DB

Movieテーブルに、categoryを追加(indexも追加）

    rails g migration AddCategolyToMovies category:string:index

## View

既存のviews/movies配下のviewをそのまま利用

## CSVデータ

category名を追加した、movie_data.csvを作成＆import

# 参考

[Railsのlink_toにパラメータを追加する - Rails Webook](https://ruby-rails.hatenadiary.com/entry/20150114/1421161200)