### PR TITLE
24_トップページのBootstrapの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "bootstrap": "^4.4.1",
-    "jquery": "^3.5.0",
+    "jquery": "~3.4.1",
     "popper.js": "^1.16.1",
     "turbolinks": "^5.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,10 +3872,10 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@^3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@~3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
# 概要
「24_トップページのBootstrapの修正」のチケットを実施
トップページのハンバーガーメニューが正常に動作していないため、機能する様にBootstrapを修正する。

## ブランチ名
`feature/improve_bootstrap`

# 実施内容
トップページのハンバーガーメニューが正常に動作していない原因を確認した上で、対応方法を検討実施する

## 現象
bootstrapのナビゲーションバーを使用して作成した、ハンバーガメニューがクリックしても動作しない。
トップページのハンバーガーメニューを押下した際、chrome検証ツールのコンソールに、以下のエラーが出力されている。

```bash
bootstrap.js:1498 Uncaught TypeError: Cannot convert object to primitive value
    at RegExp.test (<anonymous>)
    at HTMLDivElement.<anonymous> (bootstrap.js:1498)
    at Function.each (jquery.js:325)
    at jQuery.fn.init.each (jquery.js:165)
    at jQuery.fn.init._jQueryInterface [as collapse] (bootstrap.js:1492)
    at HTMLDivElement.<anonymous> (bootstrap.js:1552)
    at Function.each (jquery.js:325)
    at jQuery.fn.init.each (jquery.js:165)
    at HTMLButtonElement.<anonymous> (bootstrap.js:1547)
    at HTMLDocument.dispatch (jquery.js:4670)
(anonymous) @ bootstrap.js:1498
each @ jquery.js:325
each @ jquery.js:165
_jQueryInterface @ bootstrap.js:1492
(anonymous) @ bootstrap.js:1552
each @ jquery.js:325
each @ jquery.js:165
(anonymous) @ bootstrap.js:1547
dispatch @ jquery.js:4670
elemData.handle @ jquery.js:4490
```

## 原因
[検索した記事](https://github.com/twbs/bootstrap/issues/30553)より、
2020/4/10にアップデートされたjquery 3.5.0に伴い顕在化した不具合（と想定される）

## 対処方法
jqueryを3.5.0から3.4.1にダウングレードする
Rails6でwebpackerを使用しているため、pakage.jsonのjqueryのバージョンを3.4.1に書き換え、yarn installを実施
→ ハンバーガメニューが動作することを確認。

なお、根本的な修正はBootstrap 4.4.2版で適用される模様

# 参考

[Bootstrap data-toggle for collapse failing · Issue #2147 · LD4P/sinopia_editor](https://github.com/LD4P/sinopia_editor/issues/2147)

[Bootstrap v4.4.1 collapse doesn't work with jQuery v3.5.0 · Issue #30553 · twbs/bootstrap](https://github.com/twbs/bootstrap/issues/30553)

[package.json のチルダ(~) とキャレット(^) - Qiita](https://qiita.com/sotarok/items/4ebd4cfedab186355867)