### PR TITLE
31_検索機能の追加(テキスト教材)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -215,3 +215,7 @@ img {
   box-shadow: 0px 0px 2px;
   text-decoration: none;
 }
+
+.hidden{
+  display: none;
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,3 +7,4 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("bootstrap/dist/js/bootstrap")
+

--- a/app/javascript/packs/texts.js
+++ b/app/javascript/packs/texts.js
@@ -5,7 +5,7 @@ $(function() {
         var val = $(this).val();
         
         $('.card-title').each(function() {
-            if($(this).text().indexOf(val) != -1){
+            if($(this).text().toLowerCase().indexOf(val.toLowerCase()) != -1){
                 $(this).parents('#text').removeClass("hidden")
                 $(this).parents('#text').addClass("d-flex")
             }else{

--- a/app/javascript/packs/texts.js
+++ b/app/javascript/packs/texts.js
@@ -1,0 +1,21 @@
+$(function() {
+
+    $("#search-text").keyup(function(){
+
+        var val = $(this).val();
+        
+        $('.card-title').each(function() {
+            if($(this).text().indexOf(val) != -1){
+                $(this).parents('#text').removeClass("hidden")
+                $(this).parents('#text').addClass("d-flex")
+            }else{
+                $(this).parents('#text').removeClass("d-flex")
+                $(this).parents('#text').addClass("hidden")
+            }
+        });
+
+    });
+
+});
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_pack_tag 'texts', 'data-turbolinks-track': 'reload' %>
   </head>
 
   <body>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -15,7 +15,7 @@
     <h2 class="text-content">テキスト教材</h2>
   <div class="row">
     <% @texts.each do |text, i| %>
-    <div class="d-flex col-lg-4">
+    <div class="d-flex col-lg-4" id="text">
       <a href="/texts/<%= text.id %>/" class="card">
         <img class="card-img-top" src="/no_image.jpeg">
         <div class="card-body">
@@ -31,3 +31,4 @@
     <% end %>
   </div>
 </div>
+


### PR DESCRIPTION
テキスト教材の検索機能をJavascript&jQueryで実装しました。また、タグ検索機能は別タスクに設定いたしました。

参考記事
https://qiita.com/kazu56/items/557740f398e82fc881df