### PR TITLE
32_レスポンシブ対応

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,9 +11,10 @@
     @extend .alert-danger;
 }
 
-body {
-  padding-top: 56px;
-}
+// レスポンシブル対応のため@mediaへ移動
+// body {
+//   padding-top: 70px;
+// }
 
 .container-login {
   @extend .container-fluid;
@@ -22,26 +23,31 @@ body {
 }
 
 // aws_texts index
-#container {
-  padding: 30px 0 80px 0;
-  margin: 0 auto;
-}
+// レスポンシブル対応のため@mediaへ移動
+// #container {
+//   padding: 30px 0 80px 0;
+//   margin: 0 auto;
+// }
+
 #container table {
   table-layout: fixed;
   font-size: 17px;
 }
-#contents p {
-  width: 710px;
+
+#contents {
+  max-width: 710px;
   margin: 0 auto;
   padding-bottom: 15px;
 }
-.text-center {
-  text-align: center;
-}
-.table-container {
-  width: 710px;
-  margin: 0 auto;
-}
+// bootstrapの既定クラスなのでコメントアウト
+// .text-center {
+//   text-align: center;
+// }
+// 上位のタグで指定済みなのでコメントアウト
+// .table-container {
+//   width: 710px;
+//   margin: 0 auto;
+// }
 
 .table {
   width: 100%;
@@ -57,9 +63,10 @@ table {
   border-collapse: collapse;
 }
 
-.text-white {
-  color: #fff !important;
-}
+// bootstrapの既定クラスなのでコメントアウト
+// .text-white {
+//   color: #fff !important;
+// }
 
 .w-1 {
   width: 10%;
@@ -70,24 +77,28 @@ table {
 }
 
 .aws-content {
-  padding: 60px 0 80px 0;
-  width: 710px;
+  // padding: 60px 0 80px 0;
+  max-width: 710px;
+  margin: 0 auto;
+}
+
+.line-content {
+  max-width: 450px;
   margin: 0 auto;
 }
 
 
 
-
 // 質問一覧ページのスタイル
 .question-form{
-  width:630px;
+  max-width:630px;
   margin:0 auto;
 }
 .question-parent{
   border: 2px solid #000000;
   border-radius: 10px;
   display:flex;
-  width:630px;
+  max-width:630px;
   padding: 15px;
   margin: 0 auto;
   margin-bottom:50px;
@@ -113,8 +124,8 @@ table {
 
 // 質問詳細ページのスタイル
 #question {
-  padding: 60px 0 80px 0;
-  width: 710px;
+  // padding: 60px 0 80px 0;
+  max-width: 710px;
   margin: 0 auto;
 }
 
@@ -136,8 +147,8 @@ table {
 
 // 動画一覧ページ
 #movie {
-  padding: 120px 0 80px 0;
-  width: 990px;
+  // padding: 120px 0 80px 0;
+  max-width: 710px;
   margin: 0 auto;
 }
 
@@ -151,9 +162,10 @@ table {
   margin-bottom: 0px;
 }
 
-.video-content iframe{
-  width: 560px;
-  height: 315px;
+.video-content{
+  max-width: 560px;
+  margin: auto;
+  // height: 315px;
 }
 
 .paginate-container {
@@ -166,23 +178,28 @@ table {
 .form-control{
   margin: auto;
   padding: 0 20px;
-  max-width: 400px;
-  min-width: 300px;
+  // max-width: 400px;
+  // min-width: 300px;
 }
 
-
-
-.text-content{
-  text-align: center;
+.search-form{
+  max-width: 350px;
 }
 
-.col-lg-4{
-  padding: 30px 30px 30px 30px;
-}
+// bootstrapの.text-centerに置き換えたため削除
+// .text-content{
+//   text-align: center;
+// }
 
-.card-deck{
-  margin:10px 0px 10px 0px;
-}
+// bootstrapクラス上書きなので.p-4に置き換え
+// .col-lg-4{
+//   padding: 30px 30px 30px 30px;
+// }
+
+// bootstrapクラス上書き,かつhtmlで利用されていないクラスなので削除
+// .card-deck{
+//   margin:10px 0px 10px 0px;
+// }
 
 
 .row-eq-height {
@@ -190,13 +207,14 @@ table {
   flex-wrap: wrap;
 }
 
-.card-title {
+// bootstrapクラス上書きしないよう変更
+#text a  {
   color: black;
 }
 
-.card-text{
-  color: black;
-}
+// .card-text{
+//   color: black;
+// }ß
 
 .stretched-link:hover {
   text-decoration: none;
@@ -218,4 +236,70 @@ img {
 
 .hidden{
   display: none;
+}
+
+
+@media(min-width: 0px){
+  // 全ページ共通
+  body {
+    padding-top: 98px;
+  }
+
+  #container {
+    width: 90%;
+    padding: 30px 0 80px 0;
+    margin: 0 auto;
+  }
+
+  #container h2 {
+    font-size: 40px;
+  }
+
+  // ナビゲーションバー
+  .navbar a {
+    font-size: 3em;
+  }
+
+  .navbar .navbar-nav a {
+    font-size: 2em;
+  }
+
+}
+
+@media(min-width: 992px){
+  // 全ページ共通
+  body {
+    padding-top: 70px;
+  }
+
+  #container {
+    width: 990px;
+    padding: 120px 0 80px 0;
+  }
+
+  #container h2 {
+    font-size: 30px;
+  }
+
+  // ナビゲーションバー
+  .navbar a {
+    font-size: 30px;
+  }
+
+  .navbar .navbar-nav a {
+    font-size: 14px;
+  }
+}
+
+@media(min-width: 1200px){
+  // 全ページ共通
+  #container{
+    width: 1200px;
+  }
+
+  // ナビゲーションバー
+  .navbar .navbar-nav a {
+    font-size: 18px;
+  }
+
 }

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,30 +1,28 @@
-<div id="container">
-  <section id="contents">
-    <div class="text-center">
-      <h2>AWS講座</h2>
-    </div>
-  
-    <p>
-      注意!!!:AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
-    </p>
-  
-    <div class="table-container">
-      <table class="table table-striped">
-        <thead class="bg-primary text-white">
-          <tr>
-          <th class="w-1">No.</th>
-          <th class="w-5">内容</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @awstexts.each.with_index(1) do |awstext, i| %>
-              <tr>
-                <td><%= i %></td>
-                <td><%= link_to awstext.title,aws_text_path(awstext.id) %></td>
-              </tr>
-            <% end %>
-        </tbody>
-      </table>
-    </div>
-  </section>
-</div>
+<section id="contents">
+  <div class="text-center">
+    <h2>AWS講座</h2>
+  </div>
+
+  <p>
+    注意!!!:AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。
+  </p>
+
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead class="bg-primary text-white">
+        <tr>
+        <th class="w-1">No.</th>
+        <th class="w-5">内容</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @awstexts.each.with_index(1) do |awstext, i| %>
+            <tr>
+              <td><%= i %></td>
+              <td><%= link_to awstext.title,aws_text_path(awstext.id) %></td>
+            </tr>
+          <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,9 @@
   <body>
     <%= render 'layouts/header' %>
     <%= render 'layouts/notifications' %>
-    <%= yield %>
+    <div id="container">
+      <%= yield %>
+    </div>
     <%= render 'layouts/footer' %>
   </body>
 </html>

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -1,28 +1,26 @@
-<div id="container">
-  <section id="contents">
-    <div class="text-center">
-      <h2 class="text-success">LINE@</h2>
-    </div>
+<section id="contents">
+  <div class="text-center">
+    <h2 class="text-success">LINE@</h2>
+  </div>
 
-    <div class="table-container">
-      <table class="table table-striped">
-        <thead class="bg-success text-white">
-          <tr>
-          <th class="w-1">No.</th>
-          <th class="w-3">ジャンル</th>
-          <th class="w-5">内容</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @lines.each.with_index(1) do |line, i| %>
-              <tr>
-                <td><%= i %></td>
-                <td><%= line.genre %></td>
-                <td><%= link_to line.title,line_path(line.id) %></td>
-              </tr>
-            <% end %>
-        </tbody>
-      </table>
-    </div>
-  </section>
-</div>
+  <div class="table-container">
+    <table class="table table-striped">
+      <thead class="bg-success text-white">
+        <tr>
+        <th class="w-1">No.</th>
+        <th class="w-3">ジャンル</th>
+        <th class="w-5">内容</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @lines.each.with_index(1) do |line, i| %>
+            <tr>
+              <td><%= i %></td>
+              <td><%= line.genre %></td>
+              <td><%= link_to line.title,line_path(line.id) %></td>
+            </tr>
+          <% end %>
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/app/views/lines/show.html.erb
+++ b/app/views/lines/show.html.erb
@@ -1,3 +1,3 @@
-<div class="aws-content">
+<div class="line-content">
   <p><%= markdown(@line.content) %></p>
 </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-5 question-form">
+<div class="question-form">
     <h3 class="pt-5">新規登録</h3>
     <%= form_for(@question) do |f| %>
         <%= f.label :title, "[質問]",class: "control-label my-2" %>

--- a/app/views/shared/_video.html.erb
+++ b/app/views/shared/_video.html.erb
@@ -1,7 +1,7 @@
 <div class="video-contents">
     <p class="video-title"><%= add_level_display(video_counter) %><%= video.title %> </p>
-    <div class="video-content">
-      <iframe src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <div class="video-content embed-responsive embed-responsive-4by3">
+      <iframe class="embed-responsive-item" src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
     <% if video.source_code_url.present? %>
       <a href=<%= video.source_code_url %> class="video-source-link">ソースコード</a>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -12,10 +12,10 @@
     </form>
   </div>
 
-    <h2 class="text-content">テキスト教材</h2>
+    <h2 class="text-center">テキスト教材</h2>
   <div class="row">
     <% @texts.each do |text, i| %>
-    <div class="d-flex col-lg-4" id="text">
+    <div class="d-flex col-lg-4 p-4" id="text">
       <a href="/texts/<%= text.id %>/" class="card">
         <img class="card-img-top" src="/no_image.jpeg">
         <div class="card-body">


### PR DESCRIPTION
「32_レスポンシブ対応」のチケットを実施

逆転教材アプリをレスポンシブ対応する

### ブランチ名

`feature/responsive`

# 実施内容

### 全ページ共通

- 画面幅ごとのスタイル設定を行うためのメディアクエリの設定追加(application.scss)
- 画面縮小時にコンテンツタイトルのfont-sizeを拡大
- `width,margin`を設定した`#container`を全教材ページに適用
(application.htmlに追加し、個別ページから削除)
- xsサイズ時の画面幅溢れを改善
aws_texts, texts,questions,lineページ（固定幅指定を解除、`max-width`を適用）

### ナビゲーションバー

- 画面縮小時にロゴの拡大
- ナビメニューのフォントサイズを画面幅に応じて変更

### 動画画面

- 動画埋め込み`<ifame>`タグに`.embed-responsive`を適用

### その他改善

- bootstrapで用意されているクラスの上書きを排除（別クラスを用意）
- 使用していないスタイルを削除

# 参考資料

[メディアクエリの使用](https://developer.mozilla.org/ja/docs/Web/CSS/Media_Queries/Using_media_queries)

[embed](https://getbootstrap.jp/docs/4.4/utilities/embed/)

[Bootstrap 4 Cheat Sheet - The ultimate list of Bootstrap classes](https://hackerthemes.com/bootstrap-cheatsheet/)