### PR TITLE
35_solutionクラスのRspecの実装(新バージョン)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.rbc
 capybara-*.html
-.rspec
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /db/*.sqlite3-[0-9]*

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require rails_helper
+--format documentation
+--color

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,12 @@ gem 'rouge'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  # Rails用のテストフレームワーク
+  gem 'rspec-rails'
+  # モデルに関するテストデータ作成用
+  gem 'factory_bot_rails'
+  # ダミーデータの生成
+  gem 'faker'
 end
 
 group :development do
@@ -32,7 +38,6 @@ group :development do
   gem 'pry-byebug'
   gem 'pry-doc'
   gem 'pry-rails'
-  gem 'rspec-rails'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,13 @@ GEM
       devise (>= 4.7.1)
     diff-lcs (1.3)
     erubi (1.9.0)
+    factory_bot (5.2.0)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.2.0)
+      factory_bot (~> 5.2.0)
+      railties (>= 4.2.0)
+    faker (2.11.0)
+      i18n (>= 1.6, < 2)
     ffi (1.12.2)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -282,6 +289,8 @@ DEPENDENCIES
   devise
   devise-bootstrap-views
   devise-i18n
+  factory_bot_rails
+  faker
   jbuilder (~> 2.7)
   kaminari
   listen (>= 3.0.5, < 3.2)

--- a/config/initializers/generators.rb
+++ b/config/initializers/generators.rb
@@ -5,4 +5,11 @@ Rails.application.config.generators do |g|
     g.helper false
     g.template_engine :erb
     g.test_framework false
+    g.test_framework :rspec,
+    fixtures: true,
+    view_specs: false,
+    routing_specs: false,
+    helper_specs: false,
+    controller_specs: false,
+    request_specs: true
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,11 @@
 ja:
   activerecord:
+    models:
+      solution: 質問
+    attributes:
+      solution:
+        detail: 詳細
+
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/spec/factories/solution.rb
+++ b/spec/factories/solution.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+    factory :detail_nil_solution, class: Solution do
+        detail {nil}
+        question
+    end
+
+    factory :not_nil_solution, class: Solution do
+        detail {Faker::String.random}
+        question
+    end
+
+    factory :question do
+        title {Faker::String.random}
+        detail {Faker::String.random}
+    end
+end

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+RSpec.describe Solution, type: :model do
+    describe "Solution_modelのテスト" do
+        context "detailが空の場合" do
+            let(:detail_nil_solution){FactoryBot.build(:detail_nil_solution)}
+            it "validationエラーが起こる" do
+                expect(detail_nil_solution).not_to be_valid
+            end
+        end
+        context "detailaが空でない場合" do
+            let(:not_nil_solution){FactoryBot.build(:not_nil_solution)}
+            it "validationエラーが起こらない" do
+                expect(not_nil_solution).to be_valid
+            end
+        end
+    end
+end

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
+require 'pry'
 RSpec.describe Solution, type: :model do
     describe "Solution_modelのテスト" do
+        
         context "detailが空の場合" do
             let(:detail_nil_solution){FactoryBot.build(:detail_nil_solution)}
             it "validationエラーが起こる" do
                 expect(detail_nil_solution).not_to be_valid
+                expect(detail_nil_solution.errors.full_messages).to include "詳細を入力してください"
             end
         end
         context "detailaが空でない場合" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
+  config.include FactoryBot::Syntax::Methods
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.key?(:aggregate_failures)
+  end
 end


### PR DESCRIPTION
新たなブランチで、rspec,faker,factorybotを使ってsolutionモデルのテストを実装しました。
テストの環境構築は共同開発のグループに貼っていただいた方法で行いました。