### PR TITLE
37_動画教材のタグ検索機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'devise-bootstrap-views'
 gem 'kaminari'
 gem 'redcarpet'
 gem 'rouge'
+gem 'acts-as-taggable-on'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2)
+    acts-as-taggable-on (6.5.0)
+      activerecord (>= 5.0, < 6.1)
     arbre (1.2.1)
       activesupport (>= 3.0.0)
     bcrypt (3.1.13)
@@ -284,6 +286,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin
+  acts-as-taggable-on
   bootsnap (>= 1.4.2)
   byebug
   devise

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -245,6 +245,15 @@ img {
   display: none;
 }
 
+.tag-search{
+  max-width: 710px;
+  margin: 30px auto;
+}
+
+.tag-btns {
+  text-align: center;
+}
+
 @media(min-width: 0px){
   // 全ページ共通
   body {

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -5,6 +5,13 @@ class MoviesController < ApplicationController
     @search_category = params[:category] || @default_categories
     @movies = Movie.where(category: @search_category).page(params[:page])
     @search_movies = Movie.where(category: @default_category)
+
+    # タグ検索用
+    @most_used_tags = ActsAsTaggableOn::Tag.most_used(10)
+    if params[:tag_list]
+      # debugger
+      @movies = Movie.tagged_with(params[:tag_list]).page(params[:page])
+    end
   end
   
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -6,12 +6,12 @@ class MoviesController < ApplicationController
     @movies = Movie.where(category: @search_category).page(params[:page])
     @search_movies = Movie.where(category: @default_category)
 
-    # タグ検索用
-    @most_used_tags = ActsAsTaggableOn::Tag.most_used(10)
-    if params[:tag_list]
-      # debugger
-      @movies = Movie.tagged_with(params[:tag_list]).page(params[:page])
+    # タグ表示用
+    @tags = Movie.tag_counts_on(:tags).order('count DESC')
+    if params[:tag_name]
+      @movies = @movies.tagged_with(params[:tag_name], :any => true).page(params[:page])
     end
   end
+
   
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
 
+  include ActsAsTaggableOn::TagsHelper
   def markdown(text)
     render_options = {
       filter_html: false,

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,3 +1,4 @@
 class Movie < ApplicationRecord
   validates :title, :url, presence: true
+  acts_as_taggable_on :tags
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -6,27 +6,20 @@
               placeholder="動画教材を探す" aria-label="Username" aria-describedby="search-form">
     </form>
   </div>
-<% end %>
-
-<form>
-  <div class="form-group">
-    <label class="control-label">タグで動画教材を探す</label>
-    <% @most_used_tags.each_with_index do |tag_data, i| %>
-      <div class="form-check">
-          <input class="form-check-input" type="checkbox" id="tagSelect<%= i %>" checked>
-          <label class="form-check-label" for="tagSelect<%= i %>"><%= tag_data.name %> </label>
-      </div>
-    <% end %>
-  </div>
-</form>
 
 <div class="field">
 </div>
 
-<%= form_tag(movies_path, method: "get") do %>
-  <%= label :tag_list, "タグで動画教材を探す" %><br>
-  <%= text_field_tag :tag_list, @most_used_tags.join(','), class: "form-control" %>
-  <%= submit_tag "送信",class: "btn btn-primary btn-block mt-4 py-2"%>
+<div class="tag-search border border-info py-2">
+  <h5 class="text-center">タグ検索</h5>
+  <div class="tag-btns">
+  <%= link_to "すべて(#{@tags.count})", movies_path, class:"btn btn-info m-1" %>
+  <% @tags.each do |tag| %>
+    <%= link_to "#{tag.name} (#{tag.count})", movies_path(tag_name: tag.name), class:"btn btn-sm btn-info m-1" %>
+  <% end %>
+  </div>
+</div>
+
 <% end %>
 
 <section id="movie">

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -8,6 +8,27 @@
   </div>
 <% end %>
 
+<form>
+  <div class="form-group">
+    <label class="control-label">タグで動画教材を探す</label>
+    <% @most_used_tags.each_with_index do |tag_data, i| %>
+      <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="tagSelect<%= i %>" checked>
+          <label class="form-check-label" for="tagSelect<%= i %>"><%= tag_data.name %> </label>
+      </div>
+    <% end %>
+  </div>
+</form>
+
+<div class="field">
+</div>
+
+<%= form_tag(movies_path, method: "get") do %>
+  <%= label :tag_list, "タグで動画教材を探す" %><br>
+  <%= text_field_tag :tag_list, @most_used_tags.join(','), class: "form-control" %>
+  <%= submit_tag "送信",class: "btn btn-primary btn-block mt-4 py-2"%>
+<% end %>
+
 <section id="movie">
   <div class="default-video">
     <%= render partial: 'shared/video', collection: @movies, as: "video" %>

--- a/app/views/shared/_video.html.erb
+++ b/app/views/shared/_video.html.erb
@@ -1,7 +1,12 @@
 <div class="video-contents">
     <p class="video-title"><%= add_level_display(video_counter) %><%= video.title %> </p>
-    <% video.tag_list.each do |tag| %>
-      <btn class="btn btn-sm btn-info"> <%= tag %> </btn> 
+    <% unless video.tag_list.empty? %>
+      <div class="video-tag my-2">
+        <span>タグ: </span>
+        <% video.tag_list.each do |tag| %>
+          <%= link_to tag, movies_path(tag_name: tag), class:"btn btn-sm btn-info" %>
+        <% end %>
+      </div>
     <% end %>
     <div class="video-content embed-responsive embed-responsive-16by9">
       <iframe class="embed-responsive-item" src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/app/views/shared/_video.html.erb
+++ b/app/views/shared/_video.html.erb
@@ -1,5 +1,8 @@
 <div class="video-contents">
     <p class="video-title"><%= add_level_display(video_counter) %><%= video.title %> </p>
+    <% video.tag_list.each do |tag| %>
+      <btn class="btn btn-sm btn-info"> <%= tag %> </btn> 
+    <% end %>
     <div class="video-content embed-responsive embed-responsive-16by9">
       <iframe class="embed-responsive-item" src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>

--- a/db/csv_data/tag_data.csv
+++ b/db/csv_data/tag_data.csv
@@ -1,0 +1,17 @@
+title,tags,,,
+人生逆転サロンの活用法,使い方,サロン,,
+Slackの使い方,slack,使い方,,
+プログラミングを学習するための基礎知識,基礎知識,プログラミング,,
+Gitの基本,git,使い方,clone,
+Gitを使ったクローン、プルリク、マージの流れについて解説,git,clone,pull,マージ
+ソースコードをリモートリポジトリにプッシュするときの流れ,git,push,,
+Rubyで使用する主なクラスについて,ruby,クラス,,
+putsについて,ruby,puts,出力,
+変数について,ruby,変数,,
+Hello World アプリの解説（実践的なコントローラの作り方）,rails,アプリ,,
+resourcesを使わないCRUDアプリの解説,rails,アプリ,,
+resourcesを使ったCRUDアプリの解説,rails,アプリ,,
+デバッグツールの使い方,rails,gem,デバッグ,
+CSVデータインポートアプリの解説,rails,csv,rake,
+Rakeタスクの実装,rails,rake,,
+Deviseを使ったログイン機能の実装,rails,gem,devise,ログイン

--- a/db/migrate/20200512110845_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110845_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,37 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table ActsAsTaggableOn.tags_table do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    create_table ActsAsTaggableOn.taggings_table do |t|
+      t.references :tag, foreign_key: { to_table: ActsAsTaggableOn.tags_table }
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    drop_table ActsAsTaggableOn.taggings_table
+    drop_table ActsAsTaggableOn.tags_table
+  end
+end

--- a/db/migrate/20200512110846_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110846_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.tags_table, :name, unique: true
+
+    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+    add_index ActsAsTaggableOn.taggings_table,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.tags_table, :name
+
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_idx'
+
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200512110847_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110847_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column ActsAsTaggableOn.tags_table, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, ActsAsTaggableOn.taggings_table)
+    end
+  end
+
+  def self.down
+    remove_column ActsAsTaggableOn.tags_table, :taggings_count
+  end
+end

--- a/db/migrate/20200512110848_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110848_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :context], name: 'taggings_taggable_context_idx'
+  end
+
+  def self.down
+    remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
+  end
+end

--- a/db/migrate/20200512110849_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110849_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE #{ActsAsTaggableOn.tags_table} MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20200512110850_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200512110850_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index ActsAsTaggableOn.taggings_table, :tag_id unless index_exists? ActsAsTaggableOn.taggings_table, :tag_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_id unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_id
+    add_index ActsAsTaggableOn.taggings_table, :taggable_type unless index_exists? ActsAsTaggableOn.taggings_table, :taggable_type
+    add_index ActsAsTaggableOn.taggings_table, :tagger_id unless index_exists? ActsAsTaggableOn.taggings_table, :tagger_id
+    add_index ActsAsTaggableOn.taggings_table, :context unless index_exists? ActsAsTaggableOn.taggings_table, :context
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+      add_index ActsAsTaggableOn.taggings_table, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index ActsAsTaggableOn.taggings_table, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/migrate/20200517144421_add_index_to_moives_title.rb
+++ b/db/migrate/20200517144421_add_index_to_moives_title.rb
@@ -1,0 +1,5 @@
+class AddIndexToMoivesTitle < ActiveRecord::Migration[6.0]
+  def change
+    add_index :movies, :title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_12_110850) do
+ActiveRecord::Schema.define(version: 2020_05_17_144421) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 2020_05_12_110850) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "category"
     t.index ["category"], name: "index_movies_on_category"
+    t.index ["title"], name: "index_movies_on_title"
   end
 
   create_table "questions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_25_140349) do
+ActiveRecord::Schema.define(version: 2020_05_12_110850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,33 @@ ActiveRecord::Schema.define(version: 2020_04_25_140349) do
     t.index ["question_id"], name: "index_solutions_on_question_id"
   end
 
+  create_table "taggings", id: :serial, force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "taggings_taggable_context_idx"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "texts", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -102,4 +129,5 @@ ActiveRecord::Schema.define(version: 2020_04_25_140349) do
   end
 
   add_foreign_key "solutions", "questions"
+  add_foreign_key "taggings", "tags"
 end

--- a/lib/tasks/import_tag_data.rake
+++ b/lib/tasks/import_tag_data.rake
@@ -1,0 +1,34 @@
+namespace :import_tag_data do
+  desc "Movieデータにタグデータを作成する"
+  task movie: :environment do
+    tag_data_list= [
+      {title:"人生逆転サロンの活用法", tags:["Introduction", "使い方", "salon"]},
+      {title:"Slackの使い方", tags:["使い方","slack"]},
+      {title:"Gitの基本", tags:["git","init","add","commit","使い方"]},
+      {title:"Gitを使ったクローン",tags:["git","使い方","clone"]},
+      {title:"ソースコードをリモートリポジトリにプッシュするときの流れ",tags:["git","pull","push"]},
+      {title:"Rubyで使用する主なクラスについて",tags:["ruby","class"]},
+      {title:"putsについて",tags:["ruby","puts","出力"]},
+      {title:"変数について",tags:["ruby","変数"]},
+      {title:"Hello World アプリの解説（実践的なコントローラの作り方）",tags:["rails","アプリ"]},
+      {title:"resourcesを使わないCRUDアプリの解説",tags:["rails","アプリ"]},
+      {title:"resourcesを使ったCRUDアプリの解説",tags:["rails","アプリ"]},
+      {title:"デバッグツールの使い方",tags:["rails","デバッグ","gem"]},
+      {title:"CSVデータインポートアプリの解説",tags:["rails","CSV","gem","インポート"]},
+      {title:"Rakeタスクの実装",tags:["rails","rake","タスク"]},
+      {title:"Deviseを使ったログイン機能の実装",tags:["rails","ログイン","gem","devise"]}
+  ]
+
+    puts "#######  インポート処理を開始します #######"
+    tag_data_list.each do |tag_data|
+      movie = Movie.find_by(title: tag_data[:title])
+      if movie
+        puts "「#{tag_data[:title]}」のタグを設定します"
+        movie.tag_list.add(tag_data[:tags])
+        movie.save
+      end
+    end
+    puts "#######  インポート処理を終了します #######"
+
+  end
+end

--- a/lib/tasks/import_tag_data.rake
+++ b/lib/tasks/import_tag_data.rake
@@ -1,6 +1,7 @@
 namespace :import_tag_data do
   desc "Movieデータにタグデータを作成する"
   task movie: :environment do
+
     tag_data_list= [
       {title:"人生逆転サロンの活用法", tags:["Introduction", "使い方", "salon"]},
       {title:"Slackの使い方", tags:["使い方","slack"]},
@@ -17,17 +18,32 @@ namespace :import_tag_data do
       {title:"CSVデータインポートアプリの解説",tags:["rails","CSV","gem","インポート"]},
       {title:"Rakeタスクの実装",tags:["rails","rake","タスク"]},
       {title:"Deviseを使ったログイン機能の実装",tags:["rails","ログイン","gem","devise"]}
-  ]
+    ]
+
+    # list = Import.csv_data(path: "db/csv_data/tag_data.csv")
+    list = []
+    CSV.foreach("db/csv_data/tag_data.csv") { |row| list << row }
 
     puts "#######  インポート処理を開始します #######"
-    tag_data_list.each do |tag_data|
-      movie = Movie.find_by(title: tag_data[:title])
+    list.each do |array|
+      # 1列目はMovieのtitle
+      movie = Movie.find_by(title: array[0])
       if movie
-        puts "「#{tag_data[:title]}」のタグを設定します"
-        movie.tag_list.add(tag_data[:tags])
+        puts "「#{array[0]}」のタグを設定します"
+        # 2列目から最終列までがtagデータ
+        movie.tag_list.add(array[1..-1])
         movie.save
       end
     end
+
+    # tag_data_list.each do |tag_data|
+    #   movie = Movie.find_by(title: tag_data[:title])
+    #   if movie
+    #     puts "「#{tag_data[:title]}」のタグを設定します"
+    #     movie.tag_list.add(tag_data[:tags])
+    #     movie.save
+    #   end
+    # end
     puts "#######  インポート処理を終了します #######"
 
   end

--- a/lib/tasks/import_tag_data.rake
+++ b/lib/tasks/import_tag_data.rake
@@ -2,25 +2,6 @@ namespace :import_tag_data do
   desc "Movieデータにタグデータを作成する"
   task movie: :environment do
 
-    tag_data_list= [
-      {title:"人生逆転サロンの活用法", tags:["Introduction", "使い方", "salon"]},
-      {title:"Slackの使い方", tags:["使い方","slack"]},
-      {title:"Gitの基本", tags:["git","init","add","commit","使い方"]},
-      {title:"Gitを使ったクローン",tags:["git","使い方","clone"]},
-      {title:"ソースコードをリモートリポジトリにプッシュするときの流れ",tags:["git","pull","push"]},
-      {title:"Rubyで使用する主なクラスについて",tags:["ruby","class"]},
-      {title:"putsについて",tags:["ruby","puts","出力"]},
-      {title:"変数について",tags:["ruby","変数"]},
-      {title:"Hello World アプリの解説（実践的なコントローラの作り方）",tags:["rails","アプリ"]},
-      {title:"resourcesを使わないCRUDアプリの解説",tags:["rails","アプリ"]},
-      {title:"resourcesを使ったCRUDアプリの解説",tags:["rails","アプリ"]},
-      {title:"デバッグツールの使い方",tags:["rails","デバッグ","gem"]},
-      {title:"CSVデータインポートアプリの解説",tags:["rails","CSV","gem","インポート"]},
-      {title:"Rakeタスクの実装",tags:["rails","rake","タスク"]},
-      {title:"Deviseを使ったログイン機能の実装",tags:["rails","ログイン","gem","devise"]}
-    ]
-
-    # list = Import.csv_data(path: "db/csv_data/tag_data.csv")
     list = []
     CSV.foreach("db/csv_data/tag_data.csv") { |row| list << row }
 
@@ -36,14 +17,6 @@ namespace :import_tag_data do
       end
     end
 
-    # tag_data_list.each do |tag_data|
-    #   movie = Movie.find_by(title: tag_data[:title])
-    #   if movie
-    #     puts "「#{tag_data[:title]}」のタグを設定します"
-    #     movie.tag_list.add(tag_data[:tags])
-    #     movie.save
-    #   end
-    # end
     puts "#######  インポート処理を終了します #######"
 
   end

--- a/lib/tasks/import_tag_data.rake
+++ b/lib/tasks/import_tag_data.rake
@@ -2,11 +2,10 @@ namespace :import_tag_data do
   desc "Movieデータにタグデータを作成する"
   task movie: :environment do
 
-    list = []
-    CSV.foreach("db/csv_data/tag_data.csv") { |row| list << row }
-
     puts "#######  インポート処理を開始します #######"
-    list.each do |array|
+    
+    CSV.foreach("db/csv_data/tag_data.csv") do |array| 
+      # binding.pry
       # 1列目はMovieのtitle
       movie = Movie.find_by(title: array[0])
       if movie


### PR DESCRIPTION
## 概要

チケット「37_動画教材のタグ検索機能の追加」の実施
各動画教材に対して、複数個のタグを割り当ててて、動画教材画面でそのタグで検索可能なように実装する。

## branch

feature/tag_search_movies

## 使用したgem

acts-as-taggable-on

## 修正内容

- gem「acts-as-taggable-on」の導入
```
rake acts_as_taggable_on_engine:install:migrations
rake db:migrate
```
- Movieモデル
acts_as_taggable_on :tagsの適用
- コントローラ
タグ一覧データの作成
選択されたタグによるMovieデータ検索の実施
- ビュー
タグ毎の件数を一覧表示
リンクボタンの設置
- rakeタスクによる動画教材へのタグデータ作成

## 参考サイト

[mbleigh/acts-as-taggable-on](https://github.com/mbleigh/acts-as-taggable-on#finding-tagged-objects)