### PR TITLE
38_動画教材画面のキーワード検索のバグ対応

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -4,7 +4,7 @@ class MoviesController < ApplicationController
     @default_categories = ['Basic', 'Git', 'Ruby', 'Ruby on Rails']
     @search_category = params[:category] || @default_categories
     @movies = Movie.where(category: @search_category).page(params[:page])
-    @search_movies = Movie.where(category: @default_category)
+    @search_movies = Movie.where(category: @default_categories)
 
     # タグ表示用
     @tags = Movie.tag_counts_on(:tags).order('count DESC')

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,6 +1,6 @@
 <div class="searched-contents video-contents hidden">
     <p class="video-title"><%= add_level_display(video_counter) %><span class="video-title-text"><%= video.title %></span> </p>
-    <div class="video-content">
+    <div class="video-content embed-responsive embed-responsive-16by9">
       <iframe src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>
     <% if video.source_code_url.present? %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,5 +1,13 @@
 <div class="searched-contents video-contents hidden">
     <p class="video-title"><%= add_level_display(video_counter) %><span class="video-title-text"><%= video.title %></span> </p>
+        <% unless video.tag_list.empty? %>
+      <div class="video-tag my-2">
+        <span>タグ: </span>
+        <% video.tag_list.each do |tag| %>
+          <%= link_to tag, movies_path(tag_name: tag), class:"btn btn-sm btn-info" %>
+        <% end %>
+      </div>
+    <% end %>
     <div class="video-content embed-responsive embed-responsive-16by9">
       <iframe src=<%= video.url %> frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     </div>


### PR DESCRIPTION
自分の環境下（一応最新の状態をpullしてブランチを切っています）ではtrelloに書いてあったエラーは起きなかったものの、動画教材を検索すると動画のサイズが小さくなってしまうエラーがあったので修正しました。