### PR TITLE
41_fontAwsomeの適用

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -179,6 +179,14 @@ table {
   justify-content: center;
 }
 
+.tag-search-title{
+  font-size: 20px; 
+}
+
+.video-tag i{
+  font-size: 20px;
+}
+
 ///text教材のページ
 .search-form{
   margin: auto;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,5 +7,5 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("bootstrap/dist/js/bootstrap")
-import '@fortawesome/fontawesome-free/js/all'
+require("@fortawesome/fontawesome-free/js/all")
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,4 +7,5 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 require("bootstrap/dist/js/bootstrap")
+import '@fortawesome/fontawesome-free/js/all'
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,6 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'texts', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'movies', 'data-turbolinks-track': 'reload' %>
-    <link href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" rel="stylesheet">
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'texts', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'movies', 'data-turbolinks-track': 'reload' %>
+    <link href="https://use.fontawesome.com/releases/v5.13.0/css/all.css" rel="stylesheet">
   </head>
 
   <body>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -10,8 +10,8 @@
 <div class="field">
 </div>
 
-<div class="tag-search border border-info py-2">
-  <h5 class="text-center">タグ検索</h5>
+<div class="tag-search border border-info py-2">  
+  <div class="tag-search-title text-center"><i class="fas fa-tags text-primary"></i>タグ検索</div>
   <div class="tag-btns">
   <%= link_to "すべて(#{@tags.count})", movies_path, class:"btn btn-info m-1" %>
   <% @tags.each do |tag| %>

--- a/app/views/shared/_video.html.erb
+++ b/app/views/shared/_video.html.erb
@@ -2,7 +2,7 @@
     <p class="video-title"><%= add_level_display(video_counter) %><%= video.title %> </p>
     <% unless video.tag_list.empty? %>
       <div class="video-tag my-2">
-        <span>タグ: </span>
+        <i class="fas fa-tags text-primary"></i>
         <% video.tag_list.each do |tag| %>
           <%= link_to tag, movies_path(tag_name: tag), class:"btn btn-sm btn-info" %>
         <% end %>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gyakuten_clone_group14",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.13.0",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -778,6 +778,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-free@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz#fcb113d1aca4b471b709e8c9c168674fbd6e06d9"
+  integrity sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg==
+
 "@rails/actioncable@^6.0.0":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"


### PR DESCRIPTION
## 概要

クローンアプリにFontAwesomeを適用させる

※viewの中にFontAwesomeのアイコン用のclass("fa-*")を使用しているが、FontAwesomeのCSS読み込みがされておらず、アイコンが表示されていないため

（参考）FontAwesome用のアイコンクラスが設定されているview

```jsx
/app/views/movies/index.html.erb
/app/views/texts/index.html.erb
```

## branch

feature/apply_fontawesome

## 実施内容

- クローンアプリにFontAwesomeを適用させる(link直接読み込みではなく、packageインストール方式）

以下のyarnでfontawesomeパッケージを適用

```bash
yarn add @fortawesome/fontawesome-free
```

application.jsにimport設定を行う

```jsx
require("@fortawesome/fontawesome-free/js/all")
```

- タグ検索にFontAwesomeアイコンを挿入

タグアイコンを使用

## 参考資料

[Font Awesome](https://fontawesome.com/)

[Rails 6 に Fort Awesome 5 を導入する - Qiita](https://qiita.com/SaitoJP/items/bda11d7bd4e8ad35331a)

[Rails 6: Webpacker+Yarn+Sprocketsを十分理解してJavaScriptを書く: 後編（翻訳）｜TechRacho（テックラッチョ）〜エンジニアの「？」を「！」に〜｜BPS株式会社](https://techracho.bpsinc.jp/hachi8833/2020_01_17/85943)